### PR TITLE
Re-organize Java role to be more efficient

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ java_version: 11.2.3
 ```
 
 Typically, using the default `java_version` is recommended (it will be updated by Humio staff as needed), but you can
-find valid versions by taking a look [here](http://static.azul.com/zulu/bin/). Note that the role will automatically
-convert `11.2.3` to `11.2+3` behind the scenes. In the previously linked list, mentions of `11.2+3` should be specified
-in `java_version` as `11.2.3` for this reason.
+find valid versions by taking a look at Zulu's [list of binaries](http://static.azul.com/zulu/bin/). Note that the role
+will automatically convert `11.2.3` to `11.2+3` behind the scenes. In the previously linked list, mentions of `11.2+3`
+should be specified in `java_version` as `11.2.3` for this reason.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -9,10 +9,13 @@ Role Variables
 --------------
 
 ```yaml
-java_version: 9.0.7
-java_zulu_mirror: https://cdn.azul.com/zulu/bin
-java_zulu_build: 1
+java_version: 11.2.3
 ```
+
+Typically, using the default `java_version` is recommended (it will be updated by Humio staff as needed), but you can
+find valid versions by taking a look [here](http://static.azul.com/zulu/bin/). Note that the role will automatically
+convert `11.2.3` to `11.2+3` behind the scenes. In the previously linked list, mentions of `11.2+3` should be specified
+in `java_version` as `11.2.3` for this reason.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,2 @@
 ---
-java_version: 11.0.1
-java_zulu_version: 11.2.3
-java_zulu_mirror: https://cdn.azul.com/zulu/bin
-java_zulu_build: 1
+java_version: 11.2.3

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   author: Martin Westergaard Lassen & Joel Watson
   description: Azul Zuul JDK for use with Humio
-  company: Humio, Inc.
+  company: Humio
 
   license: Apache
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,18 +1,23 @@
 galaxy_info:
-  author: Martin Westergaard Lassen
+  author: Martin Westergaard Lassen & Joel Watson
   description: Azul Zuul JDK for use with Humio
-  company: Humio
+  company: Humio, Inc.
 
   license: Apache
 
-  min_ansible_version: 1.2
+  min_ansible_version: 2.4
 
   platforms:
   - name: EL
     versions:
     - 7
+  - name: Ubuntu
+    versions:
+    - xenial
+    - bionic
 
   galaxy_tags:
   - java
+  - humio
 
 dependencies: []

--- a/tasks/java-Debian.yml
+++ b/tasks/java-Debian.yml
@@ -1,0 +1,14 @@
+---
+- name: add Azul Systems Java apt key
+  apt_key:
+    keyserver: keyserver.ubuntu.com
+    id: 27BC0C8CB3D81623F59BDADCB1998361219BD9C9
+
+- name: add Azul Systems Java apt repository
+  apt_repository:
+    repo: deb http://repos.azulsystems.com/{{ ansible_distribution|lower }} stable main
+    state: present
+
+- name: install JDK via apt
+  apt:
+    name: zulu-{{ java_major_version }}={{ java_zulu_version }}

--- a/tasks/java-RedHat.yml
+++ b/tasks/java-RedHat.yml
@@ -1,0 +1,13 @@
+---
+- name: add Azul Systems Java yum repository
+  yum_repository:
+    name: zulu
+    description: zulu-$releasever - Azul Systems Inc., Zulu packages for $basearch
+    baseurl: http://repos.azulsystems.com/rhel/$releasever/$basearch
+    gpgkey: http://repos.azulsystems.com/RPM-GPG-KEY-azulsystems
+    gpgcheck: yes
+    protect: yes
+
+- name: install JDK via yum
+  yum:
+    name: zulu-{{ java_major_version }}-{{ java_zulu_version }}

--- a/tasks/java-var-check.yml
+++ b/tasks/java-var-check.yml
@@ -1,0 +1,7 @@
+---
+- set_fact:
+    split_version: "{{ java_version.split('.') }}"
+- set_fact:
+    java_major_version: "{{ split_version[0] }}"
+- set_fact:
+    java_zulu_version: "{{ split_version[2] | ternary('{{ split_version[0] }}.{{ split_version[1] }}+{{ split_version[2] }}', '{{ split_version[0] }}.{{ split_version[1] }}') }}"

--- a/tasks/java-var-check.yml
+++ b/tasks/java-var-check.yml
@@ -1,7 +1,10 @@
 ---
-- set_fact:
+- name: split java_version into major/minor/patch components
+  set_fact:
     split_version: "{{ java_version.split('.') }}"
-- set_fact:
+- name: ensure java_major_version variable is set
+  set_fact:
     java_major_version: "{{ split_version[0] }}"
-- set_fact:
+- name: ensure java_zulu_version variable is set
+  set_fact:
     java_zulu_version: "{{ split_version[2] | ternary('{{ split_version[0] }}.{{ split_version[1] }}+{{ split_version[2] }}', '{{ split_version[0] }}.{{ split_version[1] }}') }}"

--- a/tasks/java-var-check.yml
+++ b/tasks/java-var-check.yml
@@ -2,9 +2,11 @@
 - name: split java_version into major/minor/patch components
   set_fact:
     split_version: "{{ java_version.split('.') }}"
-- name: ensure java_major_version variable is set
+- name: ensure java variables are set
   set_fact:
     java_major_version: "{{ split_version[0] }}"
+    zulu_major_minor_patch: "{{ split_version[0] }}.{{ split_version[1] }}+{{ split_version[2] }}"
+    zulu_major_minor: "{{ split_version[0] }}.{{ split_version[1] }}"
 - name: ensure java_zulu_version variable is set
   set_fact:
-    java_zulu_version: "{{ split_version[2] | ternary('{{ split_version[0] }}.{{ split_version[1] }}+{{ split_version[2] }}', '{{ split_version[0] }}.{{ split_version[1] }}') }}"
+    java_zulu_version: "{{ split_version[2] | ternary('{{ zulu_major_minor_patch }}', '{{ zulu_major_minor }}') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,9 @@
 ---
-- name: install JDK via yum
-  yum:
-    name: "{{ java_zulu_mirror }}/zulu{{ java_zulu_version }}-jdk{{ java_version }}-linux.x86_64.rpm"
-  when: java_zulu_mirror != 'master' and ansible_os_family == 'RedHat'
+# Ensure required parameters are set
+- name: check for required variables
+  include: java-var-check.yml
 
-- name: copy JDK
-  copy:
-    src: "zulu{{ java_zulu_version }}-jdk{{ java_version }}-linux.x86_64.rpm"
-    dest: "/tmp/zulu{{ java_zulu_version }}-jdk{{ java_version }}-linux.x86_64.rpm"
-  when: java_zulu_mirror == 'master'
-
-- name: install JDK via yum from master
-  yum:
-    name: "/tmp/zulu{{ java_zulu_version }}-jdk{{ java_version }}-linux.x86_64.rpm"
-  when: java_zulu_mirror == 'master' and ansible_os_family == 'RedHat'
-
-- name: install JDK via apt
-  apt:
-    deb: "{{ java_zulu_mirror }}/zulu{{ java_zulu_version }}-jdk{{ java_version }}-linux_amd64.deb"
-  when: java_zulu_mirror != 'master' and ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+# Install OS specific Java
+- name: Install Java for {{ ansible_os_family }}
+  include: java-{{ ansible_os_family }}.yml
+  when: ansible_os_family == 'Debian' or ansible_os_family == 'RedHat'


### PR DESCRIPTION
This changes how the role works by swapping it over to using apt and yum repositories to install the Java packages we want rather than by downloading the rpm or deb files and installing manually. This allows for a much faster run time since the package is only fetched once. The old method involved fetching a ~150MB package file every time the task to install java was run whether or not it actually had to install it. Due to the dependencies in a full Humio run, this would happen around 2-3 times over the course of the run, slowing things down a lot. Now you just have the initial slowdown from the first fetch.