### PR TITLE
Add pinning of zulu jdk versions on debian/ubuntu

### DIFF
--- a/tasks/java-Debian.yml
+++ b/tasks/java-Debian.yml
@@ -12,3 +12,19 @@
 - name: install JDK via apt
   apt:
     name: zulu-{{ java_major_version }}={{ java_zulu_version }}
+
+- name: Pin zulu-11 version
+  copy:
+    dest: "/etc/apt/preferences.d/zulu11"
+    content: |
+      Package: zulu-11
+      Pin: version 11.2+3
+      Pin-Priority: 550
+
+- name: Pin zulu-13 version
+  copy:
+    dest: "/etc/apt/preferences.d/zulu13"
+    content: |
+      Package: zulu-13
+      Pin: version 13.33+25-2
+      Pin-Priority: 550


### PR DESCRIPTION
Requested to allow standard upgrades to function and not change the JDK version Humio depends on